### PR TITLE
Modified src/index.js according to React 18.

### DIFF
--- a/ReactJS_Website/src/index.js
+++ b/ReactJS_Website/src/index.js
@@ -1,16 +1,13 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
-import {BrowserRouter} from "react-router-dom";
 
 
-ReactDOM.render(
-  <>
-    <BrowserRouter>
-      <App />
-    </BrowserRouter>
-  </>,
-  document.getElementById('root')
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
 );
 


### PR DESCRIPTION
 I have made some changes according to latest version of React 18 i.e. ReactDOM.render is no longer supported in React 18 so that import ReactDOM from react-dom/client, implement ReactDOM.createRoot instead of ReactDOM.render and wrapped App inside of React.StrictMode.